### PR TITLE
OpenWeathermap version 3.0 one call api #71

### DIFF
--- a/src/pkjs/weather/openweathermap.js
+++ b/src/pkjs/weather/openweathermap.js
@@ -23,7 +23,7 @@ OpenWeatherMapProvider.prototype.constructor = OpenWeatherMapProvider;
 OpenWeatherMapProvider.prototype._super = WeatherProvider;
 
 OpenWeatherMapProvider.prototype.withOwmResponse = function (lat, lon, callback) {
-    var url = 'https://api.openweathermap.org/data/2.5/onecall?appid=' + this.apiKey + '&lat=' + lat + '&lon=' + lon + '&units=imperial&exclude=alerts,minutely';
+    var url = 'https://api.openweathermap.org/data/3.0/onecall?appid=' + this.apiKey + '&lat=' + lat + '&lon=' + lon + '&units=imperial&exclude=alerts,minutely';
     request(url, 'GET', function (response) {
         var weatherData = JSON.parse(response);
         console.log('Found timezone: ' + weatherData.timezone);


### PR DESCRIPTION
https://github.com/mattrossman/forecaswatch2/issues/71

https://openweathermap.org/api/one-call-api claims:

> One Call API 2.5 will be deprecated on April 15, 2024.

It is NOT working today, a few weeks before that date :-(